### PR TITLE
Adds support for PDK 5.1.6.0

### DIFF
--- a/Dockerfile.dazel
+++ b/Dockerfile.dazel
@@ -21,7 +21,10 @@
 #FROM nvidia/drive_os_pdk:latest
 #FROM nvidia/drive_os_pdk:5.1.3.0-linux
 #FROM nvidia/drive_os_pdk:5.1.3.0-qnx
-FROM nvidia/drive_os_pdk:5.1.3.0-both
+#FROM nvidia/drive_os_pdk:5.1.3.0-both
+FROM nvidia/drive_os_pdk:5.1.6.0-linux
+#FROM nvidia/drive_os_pdk:5.1.6.0-qnx
+#FROM nvidia/drive_os_pdk:5.1.6.0-both
 #FROM nvidia/jetpack:4.1 
 
 # Creating the man pages directory to deal with the slim variants not having it.
@@ -29,7 +32,7 @@ RUN mkdir -p /usr/share/man/man1
 RUN rm /etc/apt/sources.list.d/* || true
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-8-jdk ca-certificates curl gnupg gdb clang-format
 
-ENV BAZEL_VERSION=0.26.0
+ENV BAZEL_VERSION=0.28.1
 
 RUN apt-get install -y --no-install-recommends \
     bash-completion \

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ To cross-compile targets for aarch64-qnx append the following flag to your build
 
 You will find the associated binaries in `//bazel-out/aarch64-fastbuild/plugins/dali/TensorRTInferOp/libtensorrtinferop.so`
 
+#### Building for older PDKs
+
+By default `--config=[D5L/D5Q/L4T]-toolchain` will target the latest supported version. Since versions might use slightly different dependencies, to build using an older build container
+you will also need to specify the exact PDK version you are targeting.
+
+- e.g. `dazel build //plugins/dali/TensorRTInferOp:libtensorrtinferop.so --config=D5L-toolchain --define platforms=drive_pdk_5.1.6.0+linux` 
+
 ### Running Compiled Targets in a Container
 
 If you want to run a target in a container, use a command similar to the following:

--- a/docker/DRIVE/Dockerfile.aarch64-linux.5.1.6.0
+++ b/docker/DRIVE/Dockerfile.aarch64-linux.5.1.6.0
@@ -13,27 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# File: DL4AGX/docker/DRIVE/Dockerfile.aarch64-linux.5.1.3.0
-# Description: Docker image for DRIVE PDK 5.1.3.0 for aarch64-linux
+# File: DL4AGX/docker/DRIVE/Dockerfile.aarch64-linux.5.1.6.0
+# Description: Docker image for DRIVE PDK 5.1.6.0 for aarch64-linux
 ############################################################################
-FROM nvidia/cuda:10.1-devel-ubuntu16.04
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
 
-ARG pdk_version=5.1.3.0
+ARG pdk_version=5.1.6.0
 
-ENV CUDA_VERSION=10.1   
-ARG cuda_version_dash=10-1
-ARG cuda_version_long=10.1.107
-ARG driver_version=418.40
+ARG base_os_version=1804
+
+ENV CUDA_VERSION=10.2   
+ARG cuda_version_dash=10-2
+ARG cuda_version_long=10.2.19
+ARG driver_version=430.17
 
 ARG cudnn_version=7.5
-ARG cudnn_version_long=7.5.0.53
+ARG cudnn_version_long=7.5.1.14
 
 ARG trt_version=5.1
-ARG trt_version_short=5.1.1
-ARG trt_version_long=5.1.1.4
-ARG target_driver=10.1-r418
+ARG trt_version_short=5.1.4
+ARG trt_version_long=5.1.4.2
+ARG target_driver=10.2-r430
 
-ARG cuda_repo_x86_64=cuda-repo-ubuntu1604-${cuda_version_dash}-local-${cuda_version_long}-${driver_version}_1.0-1_amd64.deb
+ARG cuda_repo_x86_64=cuda-repo-ubuntu${base_os_version}-${cuda_version_dash}-local-${cuda_version_long}-${driver_version}_1.0-1_amd64.deb
 ARG cuda_repo_cross_aarch64_linux=cuda-repo-cross-aarch64-${cuda_version_dash}-local-${cuda_version_long}_1.0-1_all.deb
 
 ENV CUDNN_x86_64_DEBS="libcudnn7_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd64.deb \
@@ -42,14 +44,15 @@ ENV CUDNN_x86_64_DEBS="libcudnn7_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd
 ENV CUDNN_AARCH64_LINUX_DEBS="libcudnn7-cross-aarch64_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb \
                               libcudnn7-dev-cross-aarch64_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb"
 
-ENV TENSORRT_x86_64_DEBS "libnvinfer5_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
+
+ENV tensorrt_repo_x86_64="nv-tensorrt-repo-ubuntu${base_os_version}-cuda${CUDA_VERSION}-trt${trt_version_long}-ga-20190506_1-1_amd64.deb"
+ENV TENSORRT_x86_64_DEBS="libnvinfer5_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           python-libnvinfer_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
-                          python-libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           python3-libnvinfer_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
-                          python3-libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           uff-converter-tf_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           graphsurgeon-tf_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb"
+
 
 ENV TRT_AARCH64_LINUX_DEBS="libnvinfer5-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb \
                       libnvinfer-dev-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb"
@@ -118,7 +121,7 @@ COPY pdk_files /pdk_files
 ###########################################################
 # CUDA 
 ###########################################################
-RUN mv /usr/local/cuda-${CUDA_VERSION} /tmp/cuda-backup
+RUN mv /usr/local/cuda /tmp/cuda-backup
 RUN mv /pdk_files/${cuda_repo_x86_64} cuda.deb
 RUN mv /pdk_files/${cuda_repo_cross_aarch64_linux} cuda-repo-cross-aarch64.deb
 
@@ -145,8 +148,8 @@ RUN mv /usr/lib/x86_64-linux-gnu/libcublas.so* /usr/local/cuda-${CUDA_VERSION}/t
 RUN rm -rf /usr/local/cuda \
     && ln -s /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
     
-RUN ls /tmp
-RUN rsync -a --ignore-existing /tmp/cuda-backup/lib64 /usr/local/cuda/lib64
+#RUN ls /tmp/cuda-backup
+#RUN rsync -a --ignore-existing /tmp/cuda-backup/lib64 /usr/local/cuda/lib64
 
 RUN apt-get update \
     && apt-get install -y cuda-cross-aarch64 cuda-cross-aarch64-${cuda_version_dash} --reinstall --allow-downgrades \
@@ -156,20 +159,26 @@ RUN apt-get update \
 
 RUN cp -r /usr/local/cuda-${CUDA_VERSION}/bin /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux \
     && mv /usr/local/cuda-${CUDA_VERSION}/extras /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux \
-    && ln -s /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras /usr/local/cuda-${CUDA_VERSION}/extras \
+    && ln -s /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras /usr/local/cuda-${CUDA_VERSION}/extras 
     
 RUN rm -rf /usr/local/cuda-${CUDA_VERSION}/doc
 RUN find / -name "*cublas*"
 RUN mv /usr/lib/aarch64-linux-gnu/libcublas* /usr/local/cuda/targets/aarch64-linux/lib && \
     mv /usr/include/aarch64-linux-gnu/cublas* /usr/local/cuda/targets/aarch64-linux/include 
 
-RUN cd /pdk_files \
-    && dpkg -i ${CUDNN_x86_64_DEBS}
+#RUN cd /pdk_files \
+#    && dpkg -i ${CUDNN_x86_64_DEBS}
 
 #TODO: REMOVE THE LIBNVINFER SAMPLES DEPENDENCY
 RUN cd /pdk_files \ 
+    && dpkg -i ${tensorrt_repo_x86_64} \
+    && rm -rf ${tensorrt_repo_x86_64} \
+    && apt-get update \
+    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer python-libnvinfer \
+    && dpkg -i ${CUDNN_x86_64_DEBS} \
+    && rm -rf ${CUDNN_x86_64_DEBS} \
     && dpkg -i ${TENSORRT_x86_64_DEBS} \
-    && rm -rf ${TENSORRT_x86_64_DEBS}
+    && rm -rf ${TENSORR_x86_64_DEBS}
 
 RUN mkdir -p /usr/local/cuda-${CUDA_VERSION}/dl/targets/x86_64-linux \
     && cd /usr/local/cuda-${CUDA_VERSION}/dl/targets/x86_64-linux \

--- a/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.3.0
+++ b/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.3.0
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# File: DL4AGX/docker/Jetson/Dockerfile.aarch64-qnx.5.1.3.0
+# File: DL4AGX/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.3.0
 # Description: Docker image for DRIVE PDK 5.1.3.0 for QNX
 ############################################################################
 FROM nvidia/cuda:10.1-devel-ubuntu16.04

--- a/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.6.0
+++ b/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.6.0
@@ -13,46 +13,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# File: DL4AGX/docker/DRIVE/Dockerfile.aarch64-linux.5.1.3.0
-# Description: Docker image for DRIVE PDK 5.1.3.0 for aarch64-linux
+# File: DL4AGX/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.3.0
+# Description: Docker image for DRIVE PDK 5.1.3.0 for QNX
 ############################################################################
-FROM nvidia/cuda:10.1-devel-ubuntu16.04
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
 
-ARG pdk_version=5.1.3.0
+ARG base_os_version=1804
+ARG pdk_version=5.1.6.0
 
-ENV CUDA_VERSION=10.1   
-ARG cuda_version_dash=10-1
-ARG cuda_version_long=10.1.107
-ARG driver_version=418.40
+ENV CUDA_VERSION=10.2   
+ARG cuda_version_dash=10-2
+ARG cuda_version_long=10.2.19
+ARG driver_version=430.17
 
 ARG cudnn_version=7.5
-ARG cudnn_version_long=7.5.0.53
+ARG cudnn_version_long=7.5.1.14
 
 ARG trt_version=5.1
-ARG trt_version_short=5.1.1
-ARG trt_version_long=5.1.1.4
-ARG target_driver=10.1-r418
+ARG trt_version_short=5.1.4
+ARG trt_version_long=5.1.4.2
+ARG target_driver=10.2-r430
 
-ARG cuda_repo_x86_64=cuda-repo-ubuntu1604-${cuda_version_dash}-local-${cuda_version_long}-${driver_version}_1.0-1_amd64.deb
-ARG cuda_repo_cross_aarch64_linux=cuda-repo-cross-aarch64-${cuda_version_dash}-local-${cuda_version_long}_1.0-1_all.deb
+ARG cuda_repo_x86_64=cuda-repo-ubuntu${base_os_version}-${cuda_version_dash}-local-${cuda_version_long}-${driver_version}_1.0-1_amd64.deb
+ARG cuda_repo_cross_aarch64_qnx=cuda-repo-cross-qnx-${cuda_version_dash}-local-${cuda_version_long}_1.0-1_all.deb
 
 ENV CUDNN_x86_64_DEBS="libcudnn7_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd64.deb \
                        libcudnn7-dev_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd64.deb"
 
-ENV CUDNN_AARCH64_LINUX_DEBS="libcudnn7-cross-aarch64_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb \
-                              libcudnn7-dev-cross-aarch64_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb"
+ENV CUDNN_AARCH64_QNX_DEBS="libcudnn7-cross-qnx_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb \
+                            libcudnn7-dev-cross-qnx_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb"
 
-ENV TENSORRT_x86_64_DEBS "libnvinfer5_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
+ENV tensorrt_x86_64_repo="nv-tensorrt-repo-ubuntu${base_os_version}-cuda${CUDA_VERSION}-trt${trt_version_long}-ga-20190506_1-1_amd64.deb"
+
+ENV TENSORRT_x86_64_DEBS="libnvinfer5_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           python-libnvinfer_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
-                          python-libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           python3-libnvinfer_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
-                          python3-libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           uff-converter-tf_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           graphsurgeon-tf_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb"
 
-ENV TRT_AARCH64_LINUX_DEBS="libnvinfer5-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb \
-                      libnvinfer-dev-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb"
+
+ENV TRT_AARCH64_QNX_DEBS="libnvinfer5-cross-qnx_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb \
+                          libnvinfer-dev-cross-qnx_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb"
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -118,12 +120,12 @@ COPY pdk_files /pdk_files
 ###########################################################
 # CUDA 
 ###########################################################
-RUN mv /usr/local/cuda-${CUDA_VERSION} /tmp/cuda-backup
+RUN mv /usr/local/cuda /tmp/cuda-backup
 RUN mv /pdk_files/${cuda_repo_x86_64} cuda.deb
-RUN mv /pdk_files/${cuda_repo_cross_aarch64_linux} cuda-repo-cross-aarch64.deb
+RUN mv /pdk_files/${cuda_repo_cross_aarch64_qnx} cuda-repo-cross-qnx.deb
 
 ENV REPO_DEBS="cuda.deb \
-               cuda-repo-cross-aarch64.deb"
+               cuda-repo-cross-qnx.deb"
     
 RUN dpkg -i $REPO_DEBS
  
@@ -145,29 +147,37 @@ RUN mv /usr/lib/x86_64-linux-gnu/libcublas.so* /usr/local/cuda-${CUDA_VERSION}/t
 RUN rm -rf /usr/local/cuda \
     && ln -s /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
     
-RUN ls /tmp
-RUN rsync -a --ignore-existing /tmp/cuda-backup/lib64 /usr/local/cuda/lib64
+#RUN ls /tmp
+#RUN rsync -a --ignore-existing /tmp/cuda-backup/lib64 /usr/local/cuda/lib64
 
 RUN apt-get update \
-    && apt-get install -y cuda-cross-aarch64 cuda-cross-aarch64-${cuda_version_dash} --reinstall --allow-downgrades \
+    && apt-get install -y cuda-cross-qnx --reinstall --allow-downgrades \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/cuda-packages.txt 
-
 
 RUN cp -r /usr/local/cuda-${CUDA_VERSION}/bin /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux \
     && mv /usr/local/cuda-${CUDA_VERSION}/extras /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux \
     && ln -s /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras /usr/local/cuda-${CUDA_VERSION}/extras \
+    && mkdir -p /usr/local/cuda-${CUDA_VERSION}/targets/aarch64-qnx/extras/CUPTI 
+    #&& cp -r /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras/CUPTI/include /usr/local/cuda-${CUDA_VERSION}/targets/aarch64-qnx/extras/CUPTI 
     
 RUN rm -rf /usr/local/cuda-${CUDA_VERSION}/doc
 RUN find / -name "*cublas*"
-RUN mv /usr/lib/aarch64-linux-gnu/libcublas* /usr/local/cuda/targets/aarch64-linux/lib && \
-    mv /usr/include/aarch64-linux-gnu/cublas* /usr/local/cuda/targets/aarch64-linux/include 
+RUN mv /usr/lib/aarch64-qnx-gnu/libcublas* /usr/local/cuda/targets/aarch64-qnx/lib \
+    && mv /usr/include/aarch64-qnx-gnu/cublas* /usr/local/cuda/targets/aarch64-qnx/include
 
-RUN cd /pdk_files \
-    && dpkg -i ${CUDNN_x86_64_DEBS}
+
+#RUN cd /pdk_files \
+#    && dpkg -i ${CUDNN_x86_64_DEBS}
 
 #TODO: REMOVE THE LIBNVINFER SAMPLES DEPENDENCY
-RUN cd /pdk_files \ 
+RUN cd /pdk_files \
+    && dpkg -i ${tensorrt_x86_64_repo} \
+    && rm -rf ${tensorrt_x86_64_repo} \
+    && apt-get update \
+    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer python-libnvinfer \
+    && dpkg -i ${CUDNN_x86_64_DEBS} \
+    && rm -rf ${CUDNN_x86_64_DEBS} \ 
     && dpkg -i ${TENSORRT_x86_64_DEBS} \
     && rm -rf ${TENSORRT_x86_64_DEBS}
 
@@ -185,18 +195,28 @@ RUN mkdir -p /usr/local/cuda-${CUDA_VERSION}/dl/targets/x86_64-linux \
     && rm -rf /usr/local/cuda-${CUDA_VERSION}/*sight* /usr/local/cuda-${CUDA_VERSION}/samples
 
 ###########################################################
-# ARM Linux Libs
+# QNX Libs
 ###########################################################
-RUN cd /pdk_files \
-    && dpkg -i ${CUDNN_AARCH64_LINUX_DEBS}
+COPY qnx_toolchain /qnx
+RUN rsync -a /qnx/host/linux/x86_64/ /
+#RUN mkdir -p /lib64/qnx7/stubs && mv /qnx/lib64/* /lib64/qnx7/stubs
+RUN mv /qnx/target/qnx7 /usr/aarch64-unknown-nto-qnx
+#RUN rm -rf /usr/aarch64-unknown-nto-qnx/armle-v7 /usr/aarch64-unknown-nto-qnx/x86 /usr/aarch64-unknown-nto-qnx/x86_64
+RUN rm -rf /qnx 
 
 RUN cd /pdk_files \
-    && dpkg -i ${TRT_AARCH64_LINUX_DEBS}
+    && dpkg -i ${CUDNN_AARCH64_QNX_DEBS}
 
-RUN mkdir -p /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/include /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/lib \
-    && mv /usr/lib/aarch64-linux-gnu/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/lib \
-    && mv /usr/include/aarch64-linux-gnu/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/include
+RUN cd /pdk_files \
+    && dpkg -i ${TRT_AARCH64_QNX_DEBS}
 
+RUN mkdir -p /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/include /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/lib \
+    && mv /usr/lib/aarch64-unknown-nto-qnx/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/lib \
+    && mv /usr/include/aarch64-unknown-nto-qnx/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/include
+
+ENV QNX_HOST=/
+ENV QNX_TARGET=/usr/aarch64-unknown-nto-qnx
+    
 ###########################################################
 # Sample Dependencies
 ###########################################################
@@ -223,12 +243,17 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && \
 
 RUN cd /protobuf-${PROTOBUF_VERSION} \
     && ./autogen.sh && ./configure \
-    CC=aarch64-linux-gnu-gcc \
-    CXX=aarch64-linux-gnu-g++ \
-      --host=aarch64-unknown-linux-gnu \
-      --with-protoc=/usr/local/bin/protoc \
-      --prefix=/usr/aarch64-linux-gnu/ && make -j$(nproc) install && \
-    make clean 
+    CC=$QNX_HOST/usr/bin/aarch64-unknown-nto-qnx7.0.0-gcc \
+    CXX=$QNX_HOST/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++ \
+    CXXFLAGS="-D__EXT_POSIX1_198808 -I$QNX_TARGET/usr/include -I$QNX_TARGET/usr/include/aarch64 -I$QNX_TARGET/usr/include/c++/v1 -L$QNX_TARGET/aarch64le/lib -D_POSIX_C_SOURCE=200112L -D_QNX_SOURCE -D_FILE_OFFSET_BITS=64" \
+      --host=aarch64-unknown-nto-qnx7.0.0 \
+      --build=x86_64-linux-gnu \
+      --with-sysroot=$QNX_TARGET \
+      --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le \
+      --with-protoc=/usr/local/bin/protoc && make -j$(nproc) install && \
+    make clean
+
+#RUN rm -rf /protobuf-${PROTOBUF_VERSION}
 
 ENV JPEG_TURBO_VERSION=1.5.3
 RUN curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf -
@@ -245,12 +270,12 @@ RUN cd /libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     autoreconf -fiv && \
     ./configure \
       --enable-shared \
-      CC=aarch64-linux-gnu-gcc \
-      CXX=aarch64-linux-gnu-g++ \
-      --host=aarch64-unknown-linux-gnu \
-      --prefix=/usr/aarch64-linux-gnu/ && \
+      CC=aarch64-unknown-nto-qnx7.0.0-gcc \
+      CXX=aarch64-unknown-nto-qnx7.0.0-g++ \
+      --host=aarch64-unknown-nto-qnx7.0.0 \
+      --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
-    make clean 
+    make clean
     
 RUN rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
@@ -259,30 +284,6 @@ ENV FFMPEG_VERSION=3.4.2
 RUN cd /tmp && wget https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
     tar xf ffmpeg-$FFMPEG_VERSION.tar.bz2 && \
     rm ffmpeg-$FFMPEG_VERSION.tar.bz2
-
-RUN cd /tmp/ffmpeg-$FFMPEG_VERSION && \
-    ./configure \
-      --arch=aarch64 \
-      --target_os=linux \
-      --prefix=/usr/aarch64-linux-gnu/ \
-      --disable-static \
-      --disable-all \
-      --disable-autodetect \
-      --disable-iconv \
-      --enable-shared \
-      --enable-avformat \
-      --enable-avcodec \
-      --enable-avfilter \
-      --enable-protocol=file \
-      --enable-cross-compile \
-      --enable-demuxer=mov,matroska \
-      --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb \
-      --cc=aarch64-linux-gnu-gcc \
-      --cxx=aarch64-linux-gnu-g++ \
-      --disable-stripping \
-      --extra-cflags="-D_XOPEN_SOURCE=600 -std=gnu99 -fPIC" && \
-    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
-    make clean
 
 RUN cd /tmp/ffmpeg-$FFMPEG_VERSION && \
     ./configure \
@@ -303,48 +304,35 @@ RUN cd /tmp/ffmpeg-$FFMPEG_VERSION && \
       --extra-cflags="-D_XOPEN_SOURCE=600 -std=gnu99 -fPIC" && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
     make clean
+     
+RUN cd /tmp/ffmpeg-$FFMPEG_VERSION && \
+    ./configure \
+      --arch=aarch64 \
+      --target_os=qnx \
+      --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      --disable-static \
+      --disable-all \
+      --disable-autodetect \
+      --disable-iconv \
+      --enable-shared \
+      --enable-avformat \
+      --enable-avcodec \
+      --enable-avfilter \
+      --enable-protocol=file \
+      --enable-cross-compile \
+      --enable-demuxer=mov,matroska \
+      --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb \
+      --cc=aarch64-unknown-nto-qnx7.0.0-gcc \
+      --cxx=aarch64-unknown-nto-qnx7.0.0-g++ \
+      --disable-stripping \
+      --extra-cflags="-D_XOPEN_SOURCE=600 -std=gnu99 -fPIC" && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
+    make clean
+
 
 # OpenCV
 ENV OPENCV_VERSION=3.4.3
 RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf -
-
-RUN cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_TOOLCHAIN_FILE=$PWD/../platforms/linux/aarch64-gnu.toolchain.cmake \
-          -DCMAKE_INSTALL_PREFIX=/usr/aarch64-linux-gnu/ \
-          -DBUILD_LIST=core,improc,imgcodecs \
-          -DBUILD_PNG=ON \
-          -DBUILD_TIFF=OFF \
-          -DBUILD_TBB=OFF \
-          -DBUILD_WEBP=OFF \
-          -DBUILD_JPEG=ON \
-          -DBUILD_JASPER=OFF \
-          -DBUILD_ZLIB=ON \
-          -DBUILD_EXAMPLES=OFF \
-          -DBUILD_FFMPEG=ON \
-          -DBUILD_opencv_java=OFF \
-          -DBUILD_opencv_python2=OFF \
-          -DBUILD_opencv_python3=OFF \
-          -DENABLE_NEON=OFF \
-          -DWITH_PROTOBUF=OFF \
-          -DWITH_PTHREADS_PF=OFF \
-          -DWITH_OPENCL=OFF \
-          -DWITH_OPENMP=OFF \
-          -DWITH_FFMPEG=OFF \
-          -DWITH_GSTREAMER=OFF \
-          -DWITH_GSTREAMER_0_10=OFF \
-          -DWITH_CUDA=OFF \
-          -DWITH_GTK=OFF \
-          -DWITH_VTK=OFF \
-          -DWITH_TBB=OFF \
-          -DWITH_1394=OFF \
-          -DWITH_OPENEXR=OFF \
-          -DINSTALL_C_EXAMPLES=OFF \
-          -DINSTALL_TESTS=OFF \
-          -DVIBRANTE=TRUE \
-          VERBOSE=1 ../  && \
-    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
-    cd .. && rm -rf build
 
 RUN cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
@@ -381,12 +369,57 @@ RUN cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
           VERBOSE=1 ../  && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     cd .. && rm -rf build
+
+RUN wget https://raw.githubusercontent.com/andi4191/DALI/anuragd/aarch64_dl4agx/docker/opencv-qnx.patch
+RUN cd /opencv-${OPENCV_VERSION} && git apply /opencv-qnx.patch \
+      && mkdir build && cd build && \
+      cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DVIBRANTE_PDK:STRING=/ \
+        -DCMAKE_TOOLCHAIN_FILE=$PWD/../platforms/qnx/aarch64-qnx.toolchain.cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/aarch64-unknown-nto-qnx/aarch64le  \
+        -DBUILD_LIST=core,improc,imgcodecs \
+        -DBUILD_PNG=ON \
+        -DBUILD_TIFF=OFF \
+        -DBUILD_TBB=OFF \
+        -DBUILD_WEBP=OFF \
+        -DBUILD_JPEG=ON \
+        -DBUILD_JASPER=OFF \
+        -DBUILD_ZLIB=ON \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_FFMPEG=ON \
+        -DBUILD_opencv_java=OFF \
+        -DBUILD_opencv_python2=OFF \
+        -DBUILD_opencv_python3=OFF \
+        -DENABLE_NEON=OFF \
+        -DWITH_PROTOBUF=OFF \
+        -DWITH_PTHREADS_PF=OFF \
+        -DWITH_OPENCL=OFF \
+        -DWITH_OPENMP=OFF \
+        -DWITH_FFMPEG=OFF \
+        -DWITH_GSTREAMER=OFF \
+        -DWITH_GSTREAMER_0_10=OFF \
+        -DWITH_CUDA=OFF \
+        -DWITH_GTK=OFF \
+        -DWITH_VTK=OFF \
+        -DWITH_TBB=OFF \
+        -DWITH_1394=OFF \
+        -DWITH_OPENEXR=OFF \
+        -DINSTALL_C_EXAMPLES=OFF \
+        -DINSTALL_TESTS=OFF \
+        -DVIBRANTE=TRUE \
+        VERBOSE=1 \
+    ../ && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
+    cd .. && rm -rf build
+
 # Boost
 RUN BOOST_VERSION=1_66_0 \
     && cd /usr/local \
     && curl -L https://dl.bintray.com/boostorg/release/1.66.0/source/boost_${BOOST_VERSION}.tar.gz | tar -xzf - \
     && cp -r  boost_${BOOST_VERSION}/boost  /usr/include/boost \
     && cp -r  boost_${BOOST_VERSION}/boost  /usr/aarch64-linux-gnu/include/boost \
+    && cp -r  boost_${BOOST_VERSION}/boost  /usr/aarch64-unknown-nto-qnx/aarch64le/include/boost \
     && rm -rf boost_${BOOST_VERSION}
 
 RUN rm -rf /opencv-${OPENCV_VERSION} 
@@ -420,33 +453,30 @@ RUN cd DALI && mkdir -p build && cd build && cmake \
     rsync -a install/include /usr/local/ && \
     rm -rf build
 
-RUN cd DALI && mkdir -p build_aarch64-linux && cd build_aarch64-linux && cmake \ 
+RUN cd DALI && mkdir -p build_aarch64-qnx && cd build_aarch64-qnx && cmake \
       -DCMAKE_INSTALL_PREFIX=./install \
-      -DARCH=aarch64-linux \
-      -DCMAKE_COLOR_MAKEFILE=ON \
+      -DARCH=aarch64-qnx \
       -DBUILD_NVJPEG=OFF \
       -DBUILD_TENSORFLOW=OFF \
       -DBUILD_TEST=OFF \
       -DBUILD_JPEG_TURBO=ON \
-      -DJPEG_INCLUDE_DIR=/usr/aarch64-linux-gnu/include \
-      -DJPEG_LIBRARY=/usr/aarch64-linux-gnu/lib \
+      -DJPEG_INCLUDE_DIR=/usr/aarch64-unknown-nto-qnx/aarch64le/include \
+      -DJPEG_LIBRARY=/usr/aarch64-unknown-nto-qnx/aarch64le/lib \
       -DBUILD_PYTHON=OFF \
       -DBUILD_LMDB=OFF \
       -DBUILD_NVTX=OFF \
-      -DCMAKE_TOOLCHAIN_FILE:STRING="$PWD/../platforms/aarch64-linux/aarch64-linux.toolchain.cmake" \
+      -DCMAKE_TOOLCHAIN_FILE:STRING="$PWD/../platforms/qnx/aarch64-qnx.toolchain.cmake" \
       -DBUILD_BENCHMARK=OFF \
       -DCUDA_HOST=/usr/local/cuda-${CUDA_VERSION} \
-      -DOPENCV_PATH=/usr/aarch64-linux-gnu/ \
-      -DCUDA_TARGET=/usr/local/cuda-${CUDA_VERSION}/targets/aarch64-linux \
-      -DPROTOBUF_TARGET=/usr/aarch64-linux-gnu/ \
-      -DProtobuf_LIBRARIES=/usr/aarch64-linux-gnu/lib \
-      -DFFMPEG_ROOT_DIR=/usr/aarch64-linux-gnu/ \
-      -E env LDFLAGS="-ljpeg" \
-      -DVERBOSE=1 \
+      -DOPENCV_PATH=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      -DCUDA_TARGET=/usr/local/cuda-${CUDA_VERSION}/targets/aarch64-qnx \
+      -DPROTOBUF_TARGET=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      -DProtobuf_LIBRARIES=/usr/aarch64-unknown-nto-qnx/aarch64le/lib/ \
+      -DFFMPEG_ROOT_DIR=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
       ../ && make install -j12 && \
-    cp dali/python/nvidia/dali/libdali.so /usr/aarch64-linux-gnu/lib/ && \
-    rsync -a  dali/python/nvidia/dali/include /usr/aarch64-linux-gnu/ && \
-    rsync -a install/include /usr/aarch64-linux-gnu/ && \
+    cp dali/python/nvidia/dali/libdali.so /usr/aarch64-unknown-nto-qnx/aarch64le/lib/ && \
+    rsync -a  dali/python/nvidia/dali/include /usr/aarch64-unknown-nto-qnx/aarch64le && \
+    rsync -a install/include /usr/aarch64-unknown-nto-qnx/aarch64le && \
     rm -rf build
 
 RUN rm -rf DALI
@@ -461,6 +491,6 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && \
 RUN rm -rf /protobuf-${PROTOBUF_VERSION}
 RUN rm -rf *.deb *.patch
 RUN rm -rf /pdk_files
-RUN mkdir /usr/local/cuda/targets/aarch64-qnx /usr/local/cuda/dl/targets/aarch64-qnx
+RUN mkdir /usr/local/cuda/targets/aarch64-linux /usr/local/cuda/dl/targets/aarch64-linux
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/usr/local/cuda/dl/targets/x86_64-linux/lib:/usr/local/cuda/dl/targets/x86_64-linux/lib64:/usr/lib:/lib:$LD_LIBRARY_PATH

--- a/docker/DRIVE/Dockerfile.both.5.1.6.0
+++ b/docker/DRIVE/Dockerfile.both.5.1.6.0
@@ -13,28 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# File: DL4AGX/docker/DRIVE/Dockerfile.aarch64-linux.5.1.3.0
-# Description: Docker image for DRIVE PDK 5.1.3.0 for aarch64-linux
+# File: DL4AGX/docker/DRIVE/Dockerfile.both.5.1.6.0
+# Description: Docker image for DRIVE PDK 5.1.6.0 for aarch64 and QNX
 ############################################################################
-FROM nvidia/cuda:10.1-devel-ubuntu16.04
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
 
-ARG pdk_version=5.1.3.0
+ARG base_os_version=1804
+ARG pdk_version=5.1.6.0
 
-ENV CUDA_VERSION=10.1   
-ARG cuda_version_dash=10-1
-ARG cuda_version_long=10.1.107
-ARG driver_version=418.40
+ENV CUDA_VERSION=10.2   
+ARG cuda_version_dash=10-2
+ARG cuda_version_long=10.2.19
+ARG driver_version=430.17
 
 ARG cudnn_version=7.5
-ARG cudnn_version_long=7.5.0.53
+ARG cudnn_version_long=7.5.1.14
 
 ARG trt_version=5.1
-ARG trt_version_short=5.1.1
-ARG trt_version_long=5.1.1.4
-ARG target_driver=10.1-r418
+ARG trt_version_short=5.1.4
+ARG trt_version_long=5.1.4.2
+ARG target_driver=10.2-r430
 
-ARG cuda_repo_x86_64=cuda-repo-ubuntu1604-${cuda_version_dash}-local-${cuda_version_long}-${driver_version}_1.0-1_amd64.deb
+ARG cuda_repo_x86_64=cuda-repo-ubuntu${base_os_version}-${cuda_version_dash}-local-${cuda_version_long}-${driver_version}_1.0-1_amd64.deb
 ARG cuda_repo_cross_aarch64_linux=cuda-repo-cross-aarch64-${cuda_version_dash}-local-${cuda_version_long}_1.0-1_all.deb
+ARG cuda_repo_cross_aarch64_qnx=cuda-repo-cross-qnx-${cuda_version_dash}-local-${cuda_version_long}_1.0-1_all.deb
 
 ENV CUDNN_x86_64_DEBS="libcudnn7_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd64.deb \
                        libcudnn7-dev_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd64.deb"
@@ -42,17 +44,23 @@ ENV CUDNN_x86_64_DEBS="libcudnn7_${cudnn_version_long}-1+cuda${CUDA_VERSION}_amd
 ENV CUDNN_AARCH64_LINUX_DEBS="libcudnn7-cross-aarch64_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb \
                               libcudnn7-dev-cross-aarch64_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb"
 
-ENV TENSORRT_x86_64_DEBS "libnvinfer5_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
+ENV CUDNN_AARCH64_QNX_DEBS="libcudnn7-cross-qnx_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb \
+                        libcudnn7-dev-cross-qnx_${cudnn_version_long}-1+cuda${CUDA_VERSION}_all.deb"
+
+ENV tensorrt_x86_64_repo="nv-tensorrt-repo-ubuntu${base_os_version}-cuda${CUDA_VERSION}-trt${trt_version_long}-ga-20190506_1-1_amd64.deb"
+
+ENV TENSORRT_x86_64_DEBS="libnvinfer5_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           python-libnvinfer_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
-                          python-libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           python3-libnvinfer_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
-                          python3-libnvinfer-dev_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           uff-converter-tf_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb \
                           graphsurgeon-tf_${trt_version_short}-1+cuda${CUDA_VERSION}_amd64.deb"
 
 ENV TRT_AARCH64_LINUX_DEBS="libnvinfer5-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb \
-                      libnvinfer-dev-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb"
+                            libnvinfer-dev-cross-aarch64_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb"
+
+ENV TRT_AARCH64_QNX_DEBS="libnvinfer5-cross-qnx_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb \
+                      libnvinfer-dev-cross-qnx_${trt_version_short}-1+cuda${CUDA_VERSION}_all.deb"
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -118,11 +126,13 @@ COPY pdk_files /pdk_files
 ###########################################################
 # CUDA 
 ###########################################################
-RUN mv /usr/local/cuda-${CUDA_VERSION} /tmp/cuda-backup
+#RUN mv /usr/local/cuda-${CUDA_VERSION} /tmp/cuda-backup
 RUN mv /pdk_files/${cuda_repo_x86_64} cuda.deb
 RUN mv /pdk_files/${cuda_repo_cross_aarch64_linux} cuda-repo-cross-aarch64.deb
+RUN mv /pdk_files/${cuda_repo_cross_aarch64_qnx} cuda-repo-cross-qnx.deb
 
 ENV REPO_DEBS="cuda.deb \
+               cuda-repo-cross-qnx.deb \
                cuda-repo-cross-aarch64.deb"
     
 RUN dpkg -i $REPO_DEBS
@@ -145,29 +155,43 @@ RUN mv /usr/lib/x86_64-linux-gnu/libcublas.so* /usr/local/cuda-${CUDA_VERSION}/t
 RUN rm -rf /usr/local/cuda \
     && ln -s /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
     
-RUN ls /tmp
-RUN rsync -a --ignore-existing /tmp/cuda-backup/lib64 /usr/local/cuda/lib64
+#RUN ls /tmp
+#RUN rsync -a --ignore-existing /tmp/cuda-backup/lib64 /usr/local/cuda/lib64
 
 RUN apt-get update \
     && apt-get install -y cuda-cross-aarch64 cuda-cross-aarch64-${cuda_version_dash} --reinstall --allow-downgrades \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/cuda-packages.txt 
 
+RUN apt-get update \
+    && apt-get install -y cuda-cross-qnx \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/cuda-packages.txt 
 
 RUN cp -r /usr/local/cuda-${CUDA_VERSION}/bin /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux \
     && mv /usr/local/cuda-${CUDA_VERSION}/extras /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux \
-    && ln -s /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras /usr/local/cuda-${CUDA_VERSION}/extras \
+    && ln -s /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras /usr/local/cuda-${CUDA_VERSION}/extras 
+    #&& mkdir -p /usr/local/cuda-${CUDA_VERSION}/targets/aarch64-qnx/extras/CUPTI \
+    #&& cp -r /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/extras/CUPTI/include /usr/local/cuda-${CUDA_VERSION}/targets/aarch64-qnx/extras/CUPTI 
     
 RUN rm -rf /usr/local/cuda-${CUDA_VERSION}/doc
 RUN find / -name "*cublas*"
-RUN mv /usr/lib/aarch64-linux-gnu/libcublas* /usr/local/cuda/targets/aarch64-linux/lib && \
-    mv /usr/include/aarch64-linux-gnu/cublas* /usr/local/cuda/targets/aarch64-linux/include 
+RUN mv /usr/lib/aarch64-linux-gnu/libcublas* /usr/local/cuda/targets/aarch64-linux/lib \
+    && mv /usr/lib/aarch64-qnx-gnu/libcublas* /usr/local/cuda/targets/aarch64-qnx/lib \
+    && mv /usr/include/aarch64-linux-gnu/cublas* /usr/local/cuda/targets/aarch64-linux/include \
+    && mv /usr/include/aarch64-qnx-gnu/cublas* /usr/local/cuda/targets/aarch64-qnx/include
 
-RUN cd /pdk_files \
-    && dpkg -i ${CUDNN_x86_64_DEBS}
+#RUN cd /pdk_files \
+#    && dpkg -i ${CUDNN_x86_64_DEBS}
 
 #TODO: REMOVE THE LIBNVINFER SAMPLES DEPENDENCY
 RUN cd /pdk_files \ 
+    && dpkg -i ${tensorrt_x86_64_repo} \
+    && rm -rf ${tensorrt_x86_64_repo} \
+    && apt-get update \
+    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer python-libnvinfer \
+    && dpkg -i ${CUDNN_x86_64_DEBS} \
+    && rm -rf ${CUDNN_x86_64_DEBS} \
     && dpkg -i ${TENSORRT_x86_64_DEBS} \
     && rm -rf ${TENSORRT_x86_64_DEBS}
 
@@ -197,6 +221,30 @@ RUN mkdir -p /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/include /u
     && mv /usr/lib/aarch64-linux-gnu/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/lib \
     && mv /usr/include/aarch64-linux-gnu/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-linux/include
 
+###########################################################
+# QNX Libs
+###########################################################
+
+COPY qnx_toolchain /qnx
+RUN rsync -a /qnx/host/linux/x86_64/ /
+#RUN mkdir -p /lib64/qnx7/stubs && mv /qnx/lib64/* /lib64/qnx7/stubs
+RUN mv /qnx/target/qnx7 /usr/aarch64-unknown-nto-qnx
+#RUN rm -rf /usr/aarch64-unknown-nto-qnx/armle-v7 /usr/aarch64-unknown-nto-qnx/x86 /usr/aarch64-unknown-nto-qnx/x86_64
+RUN rm -rf /qnx 
+
+RUN cd /pdk_files \
+    && dpkg -i ${CUDNN_AARCH64_QNX_DEBS}
+
+RUN cd /pdk_files \
+    && dpkg -i ${TRT_AARCH64_QNX_DEBS}
+
+RUN mkdir -p /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/include /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/lib \
+    && mv /usr/lib/aarch64-unknown-nto-qnx/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/lib \
+    && mv /usr/include/aarch64-unknown-nto-qnx/* /usr/local/cuda-${CUDA_VERSION}/dl/targets/aarch64-qnx/include
+
+ENV QNX_HOST=/
+ENV QNX_TARGET=/usr/aarch64-unknown-nto-qnx
+    
 ###########################################################
 # Sample Dependencies
 ###########################################################
@@ -230,6 +278,19 @@ RUN cd /protobuf-${PROTOBUF_VERSION} \
       --prefix=/usr/aarch64-linux-gnu/ && make -j$(nproc) install && \
     make clean 
 
+RUN cd /protobuf-${PROTOBUF_VERSION} \
+    && ./autogen.sh && ./configure \
+    CC=$QNX_HOST/usr/bin/aarch64-unknown-nto-qnx7.0.0-gcc \
+    CXX=$QNX_HOST/usr/bin/aarch64-unknown-nto-qnx7.0.0-g++ \
+    CXXFLAGS="-D__EXT_POSIX1_198808 -I$QNX_TARGET/usr/include -I$QNX_TARGET/usr/include/aarch64 -I$QNX_TARGET/usr/include/c++/v1 -L$QNX_TARGET/aarch64le/lib -D_POSIX_C_SOURCE=200112L -D_QNX_SOURCE -D_FILE_OFFSET_BITS=64" \
+      --host=aarch64-unknown-nto-qnx7.0.0 \
+      --build=x86_64-linux-gnu \
+      --with-sysroot=$QNX_TARGET \
+      --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le \
+      --with-protoc=/usr/local/bin/protoc && make -j$(nproc) install && \
+    make clean
+
+
 ENV JPEG_TURBO_VERSION=1.5.3
 RUN curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf -
 
@@ -251,6 +312,17 @@ RUN cd /libjpeg-turbo-${JPEG_TURBO_VERSION} && \
       --prefix=/usr/aarch64-linux-gnu/ && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     make clean 
+
+RUN cd /libjpeg-turbo-${JPEG_TURBO_VERSION} && \
+    autoreconf -fiv && \
+    ./configure \
+      --enable-shared \
+      CC=aarch64-unknown-nto-qnx7.0.0-gcc \
+      CXX=aarch64-unknown-nto-qnx7.0.0-g++ \
+      --host=aarch64-unknown-nto-qnx7.0.0 \
+      --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
+    make clean
     
 RUN rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
@@ -303,6 +375,31 @@ RUN cd /tmp/ffmpeg-$FFMPEG_VERSION && \
       --extra-cflags="-D_XOPEN_SOURCE=600 -std=gnu99 -fPIC" && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
     make clean
+     
+RUN cd /tmp/ffmpeg-$FFMPEG_VERSION && \
+    ./configure \
+      --arch=aarch64 \
+      --target_os=qnx \
+      --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      --disable-static \
+      --disable-all \
+      --disable-autodetect \
+      --disable-iconv \
+      --enable-shared \
+      --enable-avformat \
+      --enable-avcodec \
+      --enable-avfilter \
+      --enable-protocol=file \
+      --enable-cross-compile \
+      --enable-demuxer=mov,matroska \
+      --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb \
+      --cc=aarch64-unknown-nto-qnx7.0.0-gcc \
+      --cxx=aarch64-unknown-nto-qnx7.0.0-g++ \
+      --disable-stripping \
+      --extra-cflags="-D_XOPEN_SOURCE=600 -std=gnu99 -fPIC" && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
+    make clean
+
 
 # OpenCV
 ENV OPENCV_VERSION=3.4.3
@@ -381,12 +478,57 @@ RUN cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
           VERBOSE=1 ../  && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     cd .. && rm -rf build
+
+RUN wget https://raw.githubusercontent.com/andi4191/DALI/anuragd/aarch64_dl4agx/docker/opencv-qnx.patch
+RUN cd /opencv-${OPENCV_VERSION} && git apply /opencv-qnx.patch \
+      && mkdir build && cd build && \
+      cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DVIBRANTE_PDK:STRING=/ \
+        -DCMAKE_TOOLCHAIN_FILE=$PWD/../platforms/qnx/aarch64-qnx.toolchain.cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/aarch64-unknown-nto-qnx/aarch64le  \
+        -DBUILD_LIST=core,improc,imgcodecs \
+        -DBUILD_PNG=ON \
+        -DBUILD_TIFF=OFF \
+        -DBUILD_TBB=OFF \
+        -DBUILD_WEBP=OFF \
+        -DBUILD_JPEG=ON \
+        -DBUILD_JASPER=OFF \
+        -DBUILD_ZLIB=ON \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_FFMPEG=ON \
+        -DBUILD_opencv_java=OFF \
+        -DBUILD_opencv_python2=OFF \
+        -DBUILD_opencv_python3=OFF \
+        -DENABLE_NEON=OFF \
+        -DWITH_PROTOBUF=OFF \
+        -DWITH_PTHREADS_PF=OFF \
+        -DWITH_OPENCL=OFF \
+        -DWITH_OPENMP=OFF \
+        -DWITH_FFMPEG=OFF \
+        -DWITH_GSTREAMER=OFF \
+        -DWITH_GSTREAMER_0_10=OFF \
+        -DWITH_CUDA=OFF \
+        -DWITH_GTK=OFF \
+        -DWITH_VTK=OFF \
+        -DWITH_TBB=OFF \
+        -DWITH_1394=OFF \
+        -DWITH_OPENEXR=OFF \
+        -DINSTALL_C_EXAMPLES=OFF \
+        -DINSTALL_TESTS=OFF \
+        -DVIBRANTE=TRUE \
+        VERBOSE=1 \
+    ../ && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
+    cd .. && rm -rf build
+
 # Boost
 RUN BOOST_VERSION=1_66_0 \
     && cd /usr/local \
     && curl -L https://dl.bintray.com/boostorg/release/1.66.0/source/boost_${BOOST_VERSION}.tar.gz | tar -xzf - \
     && cp -r  boost_${BOOST_VERSION}/boost  /usr/include/boost \
     && cp -r  boost_${BOOST_VERSION}/boost  /usr/aarch64-linux-gnu/include/boost \
+    && cp -r  boost_${BOOST_VERSION}/boost  /usr/aarch64-unknown-nto-qnx/aarch64le/include/boost \
     && rm -rf boost_${BOOST_VERSION}
 
 RUN rm -rf /opencv-${OPENCV_VERSION} 
@@ -449,6 +591,32 @@ RUN cd DALI && mkdir -p build_aarch64-linux && cd build_aarch64-linux && cmake \
     rsync -a install/include /usr/aarch64-linux-gnu/ && \
     rm -rf build
 
+RUN cd DALI && mkdir -p build_aarch64-qnx && cd build_aarch64-qnx && cmake \
+      -DCMAKE_INSTALL_PREFIX=./install \
+      -DARCH=aarch64-qnx \
+      -DBUILD_NVJPEG=OFF \
+      -DBUILD_TENSORFLOW=OFF \
+      -DBUILD_TEST=OFF \
+      -DBUILD_JPEG_TURBO=ON \
+      -DJPEG_INCLUDE_DIR=/usr/aarch64-unknown-nto-qnx/aarch64le/include \
+      -DJPEG_LIBRARY=/usr/aarch64-unknown-nto-qnx/aarch64le/lib \
+      -DBUILD_PYTHON=OFF \
+      -DBUILD_LMDB=OFF \
+      -DBUILD_NVTX=OFF \
+      -DCMAKE_TOOLCHAIN_FILE:STRING="$PWD/../platforms/qnx/aarch64-qnx.toolchain.cmake" \
+      -DBUILD_BENCHMARK=OFF \
+      -DCUDA_HOST=/usr/local/cuda-${CUDA_VERSION} \
+      -DOPENCV_PATH=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      -DCUDA_TARGET=/usr/local/cuda-${CUDA_VERSION}/targets/aarch64-qnx \
+      -DPROTOBUF_TARGET=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      -DProtobuf_LIBRARIES=/usr/aarch64-unknown-nto-qnx/aarch64le/lib/ \
+      -DFFMPEG_ROOT_DIR=/usr/aarch64-unknown-nto-qnx/aarch64le/ \
+      ../ && make install -j12 && \
+    cp dali/python/nvidia/dali/libdali.so /usr/aarch64-unknown-nto-qnx/aarch64le/lib/ && \
+    rsync -a  dali/python/nvidia/dali/include /usr/aarch64-unknown-nto-qnx/aarch64le && \
+    rsync -a install/include /usr/aarch64-unknown-nto-qnx/aarch64le && \
+    rm -rf build
+
 RUN rm -rf DALI
 
 # Weird bugs with having this compiled first 
@@ -461,6 +629,5 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && \
 RUN rm -rf /protobuf-${PROTOBUF_VERSION}
 RUN rm -rf *.deb *.patch
 RUN rm -rf /pdk_files
-RUN mkdir /usr/local/cuda/targets/aarch64-qnx /usr/local/cuda/dl/targets/aarch64-qnx
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/usr/local/cuda/dl/targets/x86_64-linux/lib:/usr/local/cuda/dl/targets/x86_64-linux/lib64:/usr/lib:/lib:$LD_LIBRARY_PATH

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -1,0 +1,73 @@
+##########################################################################
+# Copyright (c) 2019 NVIDIA Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# File: DL4AGX/toolchains/BUILD
+# Description: Manage the difference between versions of PDKs 
+############################################################################
+
+# constaint_setting(name = "gcc_version")
+
+# constraint_value(
+#     name = "gcc_5.4",
+#     constaint_setting = ":gcc_version"
+# )
+
+# constraint_value(
+#     name = "gcc_7.4",
+#     constaint_setting = ":gcc_version"
+# )
+
+# constaint_setting(name = "qnx_version")
+
+# constraint_value(
+#     name = "qnx_7.0.0",
+#     constaint_setting = ":qnx_version"
+# )
+
+# platform(
+#     name = "drive_pdk_5.1.3.0+linux",
+#     constaint_values = {
+#         "@platforms//os:linux",
+#         "@platforms//cpu:aarch64",
+#         ":gcc_5.4",
+#     ],
+# )
+
+# platform(
+#     name = "drive_pdk_5.1.6.0+linux",
+#     constaint_values = {
+#         "@platforms//os:linux",
+#         "@platforms//cpu:aarch64",
+#         ":gcc_7.4",
+#     ],
+# )
+
+# platform(
+#     name = "drive_pdk_5.1.3.0+qnx",
+#     constaint_values = {
+#         "@platforms//os:qnx",
+#         "@platforms//cpu:aarch64",
+#         ":qnx_7.0.0"
+#     ],
+# )
+
+# platform(
+#     name = "drive_pdk_5.1.6.0+qnx",
+#     constaint_values = {
+#         "@platforms//os:qnx",
+#         "@platforms//cpu:aarch64",
+#         ":qnx_7.0.0"
+#     ],
+# )

--- a/toolchains/D5L/BUILD
+++ b/toolchains/D5L/BUILD
@@ -19,9 +19,23 @@
 package(default_visibility = ["//visibility:public"])
 load("//toolchains/D5L:D5L_cc_toolchain_config.bzl", "D5L_cc_toolchain_config")
 
+config_setting(
+    name = "gcc_7.4",
+    values = {"define": "platforms=drive_pdk_5.1.6.0+linux"}
+)
+
+config_setting(
+    name = "gcc_5.4",
+    values = {"define": "platforms=drive_pdk_5.1.3.0+linux"}
+)
+
 D5L_cc_toolchain_config(
     name = "D5L_toolchain_config",
     cpu = "aarch64",
+    gcc_toolchain_version = select({
+        ":gcc_5.4": "gcc5.4",
+        "//conditions:default": "gcc7.4",
+    })
 )
 
 cc_toolchain_suite(

--- a/toolchains/D5L/D5L_cc_toolchain_config.bzl
+++ b/toolchains/D5L/D5L_cc_toolchain_config.bzl
@@ -149,14 +149,24 @@ def _impl(ctx):
 
     features = [coverage_feature, debug_feature]
 
-    cxx_builtin_include_directories = [
+    gcc_include_directories_by_version = {
+        "gcc5.4": [
             "/usr/aarch64-linux-gnu/include/c++/5/",
             "/usr/aarch64-linux-gnu/include/c++/5/backward",
             "/usr/aarch64-linux-gnu/include/",
             "/usr/lib/gcc-cross/aarch64-linux-gnu/5/include",
             "/usr/lib/gcc-cross/aarch64-linux-gnu/5/include-fixed",
+        ],
+        "gcc7.4": [
+            "/usr/aarch64-linux-gnu/include/c++/7/",
+            "/usr/aarch64-linux-gnu/include/c++/7/backward",
+            "/usr/aarch64-linux-gnu/include/",
+            "/usr/lib/gcc-cross/aarch64-linux-gnu/7/include",
+            "/usr/lib/gcc-cross/aarch64-linux-gnu/7/include-fixed",
         ]
-
+    }
+    
+    cxx_builtin_include_directories = gcc_include_directories_by_version[ctx.attr.gcc_toolchain_version]
     artifact_name_patterns = []
 
     make_variables = []
@@ -235,6 +245,7 @@ D5L_cc_toolchain_config =  rule(
     implementation = _impl,
     attrs = {
         "cpu": attr.string(mandatory=True, values=["aarch64"]),
+        "gcc_toolchain_version": attr.string(mandatory=True, values=["gcc5.4", "gcc7.4"]),
     },
     provides = [CcToolchainConfigInfo],
     executable = True,


### PR DESCRIPTION
- Adds new containers for PDK 5.1.6.0.
- Adds support for targeting older PDKs
    - note: we should move to platforms entirely eventually, need to port the toolchains when ready
- Bumps bazel version 0.28.1