### PR TITLE
docker(//DRIVE/Dockerfile): (master branch) - Fix cupti and TensorRT package dependenci…

### DIFF
--- a/docker/DRIVE/Dockerfile.aarch64-linux.5.1.6.0
+++ b/docker/DRIVE/Dockerfile.aarch64-linux.5.1.6.0
@@ -128,7 +128,7 @@ ENV REPO_DEBS="cuda.deb \
     
 RUN dpkg -i $REPO_DEBS
  
-ENV CUDA_PACKAGES="nvrtc nvgraph cusolver cufft curand cusparse npp nvjpeg cudart cupti compiler misc-headers command-line-tools nvrtc-dev nvml-dev nvgraph-dev cusolver-dev cufft-dev curand-dev cusparse-dev npp-dev nvjpeg-dev cudart-dev driver-dev nvcc toolkit libraries-dev tools visual-tools"
+ENV CUDA_PACKAGES="nvrtc nvgraph cusolver cufft curand cusparse npp nvjpeg cudart cupti cupti-dev compiler misc-headers command-line-tools nvrtc-dev nvml-dev nvgraph-dev cusolver-dev cufft-dev curand-dev cusparse-dev npp-dev nvjpeg-dev cudart-dev driver-dev nvcc toolkit libraries-dev tools visual-tools"
 RUN echo "for i in \$CUDA_PACKAGES; do echo \"cuda-\$i-\${cuda_version_dash}=\${cuda_version_long}-1\";done" | bash > /tmp/cuda-packages.txt
 
 #Install CUDA 10
@@ -172,7 +172,7 @@ RUN cd /pdk_files \
     && dpkg -i ${tensorrt_repo_x86_64} \
     && rm -rf ${tensorrt_repo_x86_64} \
     && apt-get update \
-    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer python-libnvinfer \
+    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer=${trt_version_short}-1+cuda${CUDA_VERSION} python-libnvinfer=${trt_version_short}-1+cuda${CUDA_VERSION} \
     && dpkg -i ${CUDNN_x86_64_DEBS} \
     && rm -rf ${CUDNN_x86_64_DEBS} \
     && dpkg -i ${TENSORRT_x86_64_DEBS} \

--- a/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.6.0
+++ b/docker/DRIVE/Dockerfile.aarch64-qnx.5.1.6.0
@@ -127,7 +127,7 @@ ENV REPO_DEBS="cuda.deb \
     
 RUN dpkg -i $REPO_DEBS
  
-ENV CUDA_PACKAGES="nvrtc nvgraph cusolver cufft curand cusparse npp nvjpeg cudart cupti compiler misc-headers command-line-tools nvrtc-dev nvml-dev nvgraph-dev cusolver-dev cufft-dev curand-dev cusparse-dev npp-dev nvjpeg-dev cudart-dev driver-dev nvcc toolkit libraries-dev tools visual-tools"
+ENV CUDA_PACKAGES="nvrtc nvgraph cusolver cufft curand cusparse npp nvjpeg cudart cupti cupti-dev compiler misc-headers command-line-tools nvrtc-dev nvml-dev nvgraph-dev cusolver-dev cufft-dev curand-dev cusparse-dev npp-dev nvjpeg-dev cudart-dev driver-dev nvcc toolkit libraries-dev tools visual-tools"
 RUN echo "for i in \$CUDA_PACKAGES; do echo \"cuda-\$i-\${cuda_version_dash}=\${cuda_version_long}-1\";done" | bash > /tmp/cuda-packages.txt
 
 #Install CUDA 10
@@ -173,7 +173,7 @@ RUN cd /pdk_files \
     && dpkg -i ${tensorrt_x86_64_repo} \
     && rm -rf ${tensorrt_x86_64_repo} \
     && apt-get update \
-    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer python-libnvinfer \
+    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer=${trt_version_short}-1+cuda${CUDA_VERSION} python-libnvinfer=${trt_version_short}-1+cuda${CUDA_VERSION} \
     && dpkg -i ${CUDNN_x86_64_DEBS} \
     && rm -rf ${CUDNN_x86_64_DEBS} \ 
     && dpkg -i ${TENSORRT_x86_64_DEBS} \

--- a/docker/DRIVE/Dockerfile.both.5.1.6.0
+++ b/docker/DRIVE/Dockerfile.both.5.1.6.0
@@ -135,7 +135,7 @@ ENV REPO_DEBS="cuda.deb \
     
 RUN dpkg -i $REPO_DEBS
  
-ENV CUDA_PACKAGES="nvrtc nvgraph cusolver cufft curand cusparse npp nvjpeg cudart cupti compiler misc-headers command-line-tools nvrtc-dev nvml-dev nvgraph-dev cusolver-dev cufft-dev curand-dev cusparse-dev npp-dev nvjpeg-dev cudart-dev driver-dev nvcc toolkit libraries-dev tools visual-tools"
+ENV CUDA_PACKAGES="nvrtc nvgraph cusolver cufft curand cusparse npp nvjpeg cudart cupti cupti-dev compiler misc-headers command-line-tools nvrtc-dev nvml-dev nvgraph-dev cusolver-dev cufft-dev curand-dev cusparse-dev npp-dev nvjpeg-dev cudart-dev driver-dev nvcc toolkit libraries-dev tools visual-tools"
 RUN echo "for i in \$CUDA_PACKAGES; do echo \"cuda-\$i-\${cuda_version_dash}=\${cuda_version_long}-1\";done" | bash > /tmp/cuda-packages.txt
 
 #Install CUDA 10
@@ -187,7 +187,7 @@ RUN cd /pdk_files \
     && dpkg -i ${tensorrt_x86_64_repo} \
     && rm -rf ${tensorrt_x86_64_repo} \
     && apt-get update \
-    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer python-libnvinfer \
+    && apt-get download libcudnn7=${cudnn_version_long}-1+cuda${CUDA_VERSION} libcudnn7-dev=${cudnn_version_long}-1+cuda${CUDA_VERSION} libnvinfer5=${trt_version_short}-1+cuda${CUDA_VERSION} libnvinfer-dev=${trt_version_short}-1+cuda${CUDA_VERSION} uff-converter-tf graphsurgeon-tf python3-libnvinfer=${trt_version_short}-1+cuda${CUDA_VERSION} python-libnvinfer=${trt_version_short}-1+cuda${CUDA_VERSION} \
     && dpkg -i ${CUDNN_x86_64_DEBS} \
     && rm -rf ${CUDNN_x86_64_DEBS} \
     && dpkg -i ${TENSORRT_x86_64_DEBS} \


### PR DESCRIPTION
Fix for docker container image build failure. Please find the detail description at the following link:
https://forums.developer.nvidia.com/t/could-not-build-docker-image-in-dl4agx/122891

Brief Summary:

Fixed cupti dependencies
Fixed python binding package versioning for TensorRT in Dockerfiles.
This is PR different than #34 (Fix for hierarchical Dockerfiles)

Signed-off-by: Anurag Dixit <anuragd@nvidia.com>