### PR TITLE
Define undefined name e

### DIFF
--- a/tools/packaging/package.py
+++ b/tools/packaging/package.py
@@ -84,7 +84,7 @@ def determine_component_deps(bazel_bin, name, component_name):
 
     content = [x.strip() for x in content]
     for dep_str in content:
-        if dep_str[0] is not '@':  #Do not want external dependencies
+        if dep_str[0] != '@':  #Do not want external dependencies
             dep = dep_str.strip().split(":")[0]
             if dep not in BLACKLISTED_BAZEL_TARGETS:
                 component_deps.add(dep)

--- a/tools/packaging/package.py
+++ b/tools/packaging/package.py
@@ -57,7 +57,7 @@ def copy(src, dest):
         copy_tree(src, dest)
     except DistutilsFileError:
         shutil.copy(src, dest)
-    except:
+    except Exception as e:
         print('Directory not copied. Error: %s' % e)
 
 


### PR DESCRIPTION
`e` is an _undefined name_ in this context which has the potential to raise NameError at runtime.

Also, use ==/!= to compare constant literals (str, bytes, int, float, tuple) to avoid a [SyntaxWarning on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "@" is "@"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
