### PR TITLE
bevformer-int8-eq readme update

### DIFF
--- a/AV-Solutions/bevformer-int8-eq/README.md
+++ b/AV-Solutions/bevformer-int8-eq/README.md
@@ -6,7 +6,7 @@ This repository contains an end-to-end example of deploying [BEVFormer](https://
 - TensorRT 10.x
 - ONNX-Runtime 1.18.x
 - onnx-graphsurgeon
-- onnsim
+- onnxsim
 - [ModelOpt toolkit](https://github.com/NVIDIA/TensorRT-Model-Optimizer) >= 0.15.0
 - [BEVFormer_tensorrt](https://github.com/DerryHub/BEVFormer_tensorrt)
 
@@ -72,7 +72,7 @@ This script does the following post-processing actions:
 1. Prepare the calibration data:  
 ```sh
 $ cd /workspace/BEVFormer_tensorrt
-$ python /mnt/tools/calib_data_prep.py configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
+$ PYTHONPATH=$(pwd) python /mnt/tools/calib_data_prep.py configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
     --onnx_path=/mnt/models/bevformer_tiny_epoch_24_cp2_op13_post_simp.onnx \
     --trt_plugins=$PLUGIN_PATH
 ```


### PR DESCRIPTION
1. typo fix onnsim -> onnxsim
2. added PYTHONPATH=$(pwd) to ensure third_party.bev_mmdet3d to be successfully imported.