### PR TITLE
[issues/85] Added fix for ModulatedDeformableConv2d plugin for TRT>=10.3

### DIFF
--- a/AV-Solutions/bevformer-int8-eq/bevformer_trt10.patch
+++ b/AV-Solutions/bevformer-int8-eq/bevformer_trt10.patch
@@ -105,6 +105,45 @@ index 0a913c1..321e167 100644
                        GridSamplerInterpolation interp,
                        GridSamplerPadding padding, bool align_corners,
                        cudaStream_t stream);
+diff --git a/TensorRT/plugin/modulated_deformable_conv2d/modulatedDeformableConv2dPlugin.cpp b/TensorRT/plugin/modulated_deformable_conv2d/modulatedDeformableConv2dPlugin.cpp
+index 0494a8f..ed4a2b8 100644
+--- a/TensorRT/plugin/modulated_deformable_conv2d/modulatedDeformableConv2dPlugin.cpp
++++ b/TensorRT/plugin/modulated_deformable_conv2d/modulatedDeformableConv2dPlugin.cpp
+@@ -66,7 +66,11 @@ DimsExprs ModulatedDeformableConv2dPlugin::getOutputDimensions(
+   return outputDim;
+ }
+ 
+-int32_t ModulatedDeformableConv2dPlugin::initialize() noexcept { return 0; }
++int32_t ModulatedDeformableConv2dPlugin::initialize() noexcept {
++#if NV_TENSORRT_MAJOR >= 10 && NV_TENSORRT_MINOR >= 3
++#endif
++  return 0;
++}
+ 
+ void ModulatedDeformableConv2dPlugin::terminate() noexcept {}
+ 
+@@ -118,6 +122,9 @@ int32_t ModulatedDeformableConv2dPlugin::enqueue(
+     const nvinfer1::PluginTensorDesc *inputDesc,
+     const nvinfer1::PluginTensorDesc *outputDesc, const void *const *inputs,
+     void *const *outputs, void *workSpace, cudaStream_t stream) noexcept {
++#if NV_TENSORRT_MAJOR >= 10 && NV_TENSORRT_MINOR >= 3
++  cublasSetStream(m_cublas_handle, stream);
++#endif
+   int batch = inputDesc[0].dims.d[0];
+   int channels = inputDesc[0].dims.d[1];
+   int height = inputDesc[0].dims.d[2];
+@@ -286,7 +293,11 @@ DataType ModulatedDeformableConv2dPlugin::getOutputDataType(
+ void ModulatedDeformableConv2dPlugin::attachToContext(
+     cudnnContext *cudnn, cublasContext *cublas,
+     nvinfer1::IGpuAllocator *allocator) noexcept {
++#if NV_TENSORRT_MAJOR >= 10 && NV_TENSORRT_MINOR >= 3
++  cublasCreate(&m_cublas_handle);
++#else
+   m_cublas_handle = cublas;
++#endif
+ }
+ 
+ void ModulatedDeformableConv2dPlugin::detachFromContext() noexcept {}
 diff --git a/TensorRT/plugin/multi_scale_deformable_attn/multiScaleDeformableAttnKernel.cu b/TensorRT/plugin/multi_scale_deformable_attn/multiScaleDeformableAttnKernel.cu
 index e1a70ac..3bd468a 100644
 --- a/TensorRT/plugin/multi_scale_deformable_attn/multiScaleDeformableAttnKernel.cu


### PR DESCRIPTION
Fix for https://github.com/NVIDIA/DL4AGX/issues/85

**Issue**: BEVFormer `tiny` was performing with the expected accuracy, but not the `small` and `base` variants.

**Reason**: This  was due to the `modulated_deformable_conv2d` layer needing some code changes to be compatible with TensorRT 10. The `tiny` variant wasn't affected is because that layer is not present there.

**Solution**: Updated the source code for `modulated_deformable_conv2d` plugin to support TRT>=10.3 (this PR).

**Validation**: Re-compiled the plugin, built the TRT engine, and ran evaluation (as instructed in the README). See table below.

| Variant | mAP (observed)  | mAP (expected*) |
|---------|-----------------|-----------------|
| `tiny`  | 0.252  | 0.252 |
| `small` | 0.370 | 0.370 |
| `base`  | 0.416 | 0.416 |

*The expected mAP values are the ones reported in the `BEVFormer_tensorrt` repo's [README](https://github.com/DerryHub/BEVFormer_tensorrt#bevformer-pytorch).