### PR TITLE
[BEVFormer] Update ModelOpt to 0.27.1

### DIFF
--- a/AV-Solutions/bevformer-int8-eq/README.md
+++ b/AV-Solutions/bevformer-int8-eq/README.md
@@ -4,10 +4,10 @@ This repository contains an end-to-end example of deploying [BEVFormer](https://
 
 # Requirements
 - TensorRT 10.x
-- ONNX-Runtime 1.18.x
+- ONNX-Runtime 1.20.x
 - onnx-graphsurgeon
-- onnsim
-- [ModelOpt toolkit](https://github.com/NVIDIA/TensorRT-Model-Optimizer) 0.15.0
+- onnxsim
+- [ModelOpt toolkit](https://github.com/NVIDIA/TensorRT-Model-Optimizer) 0.27.1
 - [BEVFormer_tensorrt](https://github.com/DerryHub/BEVFormer_tensorrt)
 
 ## Prepare dataset
@@ -24,18 +24,18 @@ $ docker build -f docker/tensorrt.Dockerfile --no-cache --tag=$TAG .
 # How to Run
 
 ## 1. Export model to ONNX and compile plugins
-A. Download model weights from [here](https://github.com/DerryHub/BEVFormer_tensorrt#bevformer-pytorch) 
+**A.** Download model weights from [here](https://github.com/DerryHub/BEVFormer_tensorrt#bevformer-pytorch) 
  and save it in `./models`:
 ```sh
 $ wget -P ./models https://github.com/zhiqi-li/storage/releases/download/v1.0/bevformer_tiny_epoch_24.pth
 ```
 
-B. Run docker container:
+**B.** Run docker container:
 ```sh
 $ docker run -it --rm --gpus device=0 --network=host --shm-size 20g -v $(pwd):/mnt -v <path to data>:/workspace/BEVFormer_tensorrt/data $TAG
 ```
 
-C. In docker container, patch the `BEVFormer_tensorrt` folder and compile plugins:
+**C.** In docker container, patch the `BEVFormer_tensorrt` folder and compile plugins:
 ```sh
 # 1. Apply patch to BEVFormer_tensorrt with changes necessary for TensorRT 10 support
 $ cd /workspace/BEVFormer_tensorrt
@@ -47,44 +47,47 @@ $ cmake .. -DCMAKE_TENSORRT_PATH=/usr && make -j$(nproc) && make install
 ```
 > The compiled plugin will be saved in `TensorRT/lib/libtensorrt_ops.so`, which will later be used by both ModelOpt and TensorRT.
 
-D. Export simplified ONNX model from torch:
+**D.** Export ONNX model from torch:
 ```sh
 $ cd /workspace/BEVFormer_tensorrt
 $ python tools/pth2onnx.py configs/bevformer/plugin/bevformer_tiny_trt_p2.py /mnt/models/bevformer_tiny_epoch_24.pth --opset=13 --cuda --flag=cp2_op13
 $ cp checkpoints/onnx/bevformer_tiny_epoch_24_cp2_op13.onnx /mnt/models/
 ```
 
-## 2. Post-process ONNX model
+## 2. Prepare the calibration data
+**A.** Post-process ONNX model:
 ```sh
 $ export PLUGIN_PATH=/workspace/BEVFormer_tensorrt/TensorRT/lib/libtensorrt_ops.so
 $ python /mnt/tools/onnx_postprocess.py --onnx=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.onnx --trt_plugins=$PLUGIN_PATH
 ```
-> This will generate an ONNX file of same name as the input ONNX file with the suffix `*_post_simp.onnx`.
+> This will generate an ONNX file of same name as the input ONNX file with the suffix `*_post.onnx`, which will be used to generate the calibration data.
 >  May need to use `CUDA_MODULE_LOADING=LAZY` if using CUDA 12.x. No such variable is needed with CUDA 11.8.
 
 This script does the following post-processing actions:
 1. Automatically detect custom TRT ops in the ONNX model.
 2. Ensure that the custom ops are supported as a TRT plugin in ONNX-Runtime (`trt.plugins` domain).
 3. Update all tensor types and shapes in the ONNX graph with `onnx-graphsurgeon`.
-4. Simplify model with `onnxsim`.
 
-## 3. Quantize ONNX model
-1. Prepare the calibration data:  
+**B.** Prepare the calibration data:  
 ```sh
 $ cd /workspace/BEVFormer_tensorrt
 $ PYTHONPATH=$(pwd) python /mnt/tools/calib_data_prep.py configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
-    --onnx_path=/mnt/models/bevformer_tiny_epoch_24_cp2_op13_post_simp.onnx \
+    --onnx_path=/mnt/models/bevformer_tiny_epoch_24_cp2_op13_post.onnx \
     --trt_plugins=$PLUGIN_PATH
 ```
 > The calibration data will be saved in `data/nuscenes/calib_data.npz`. The script uses 600 calibration samples by default.
 >  See [instructions](https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/onnx_ptq#quantize-an-onnx-model) in the ModelOpt toolkit for more info on generating the calibration data.
 
-2. Quantize ONNX model with calibration data:  
+**Note**: the `*_post.onnx` model is only needed to generate the calibration data, so the original ONNX model can be used in the
+ quantization step (`Step 3`).
+
+## 3. Quantize ONNX model with calibration data
 ```bash
-$ python /mnt/tools/quantize_model.py --onnx_path=/mnt/models/bevformer_tiny_epoch_24_cp2_op13_post_simp.onnx \
+$ python /mnt/tools/quantize_model.py --onnx_path=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.onnx \
       --trt_plugins=$PLUGIN_PATH \
       --op_types_to_exclude MatMul \
-      --calibration_data_path=/workspace/BEVFormer_tensorrt/data/nuscenes/calib_data.npz
+      --calibration_data_path=/workspace/BEVFormer_tensorrt/data/nuscenes/calib_data.npz \
+      --simplify
 ```
 > This generates an ONNX model with suffix `.quant.onnx` with Q/DQ nodes around relevant layers.
 
@@ -94,12 +97,15 @@ $ python /mnt/tools/quantize_model.py --onnx_path=/mnt/models/bevformer_tiny_epo
   placement can vary for different models, so there may be cases where quantizing MatMul ops may be more advantageous.
   This is up to the user to decide.
 - If you're running out of memory, you may need to add `CUDA_MODULE_LOADING=LAZY` to the beginning of that
- quantization command. This is only valid for CUDA 12.x. No such variable is needed with CUDA 11.8.
+  quantization command. This is only valid for CUDA 12.x. No such variable is needed with CUDA 11.8.
+- The `--simplify` flag is optional.
+- If you wish to simply check the explicitly quantized model's runtime performance, without considering its accuracy,
+  you may also skip using the `--calibration_data_path` flag (and thus `Step 2` altogether).
 
 ## 4. Build TensorRT engine
 ```sh
-$ trtexec --onnx=/mnt/models/bevformer_tiny_epoch_24_cp2_op13_post_simp.quant.onnx \
-	      --saveEngine=/mnt/models/bevformer_tiny_epoch_24_cp2_op13_post_simp.quant.engine \
+$ trtexec --onnx=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.quant.onnx \
+	      --saveEngine=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.quant.engine \
 	      --staticPlugins=$PLUGIN_PATH \
 	      --best
 ```
@@ -113,14 +119,14 @@ Run evaluation script:
 $ cd /workspace/BEVFormer_tensorrt
 $ python tools/bevformer/evaluate_trt.py \
          configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
-         /mnt/models/bevformer_tiny_epoch_24_cp2_op13_post_simp.quant.engine \
+         /mnt/models/bevformer_tiny_epoch_24_cp2_op13.quant.engine \
          --trt_plugins=$PLUGIN_PATH
 ```
 
 # Results
 **System**: NVIDIA A40 GPU, TensorRT 10.3.0.26.
 
-BEVFormer tiny with FP16 plugins with `nv_half2` (`bevformer_tiny_epoch_24_cp2_op13_post_simp.onnx`):
+BEVFormer tiny with FP16 plugins with `nv_half2` (`bevformer_tiny_epoch_24_cp2_op13.onnx`):
 
 | Precision                                       | GPU Compute Time (median, ms) | Accuracy (NDS / mAP)   |
 |-------------------------------------------------|-------------------------------|------------------------|
@@ -130,7 +136,7 @@ BEVFormer tiny with FP16 plugins with `nv_half2` (`bevformer_tiny_epoch_24_cp2_o
 | QDQ_BEST (ModelOpt PTQ - Explicit Quantization) | 6.02                          | NDS: 0.352, mAP: 0.251 |
 
 
-BEVFormer tiny with FP16 plugins with `nv_half` (`bevformer_tiny_epoch_24_cp_op13_post_simp.onnx`):
+BEVFormer tiny with FP16 plugins with `nv_half` (`bevformer_tiny_epoch_24_cp_op13.onnx`):
 
 | Precision                                       | GPU Compute Time (median, ms) | Accuracy (NDS / mAP)   |
 |-------------------------------------------------|-------------------------------|------------------------|

--- a/AV-Solutions/bevformer-int8-eq/docker/tensorrt.Dockerfile
+++ b/AV-Solutions/bevformer-int8-eq/docker/tensorrt.Dockerfile
@@ -55,7 +55,7 @@ RUN pip install --extra-index-url https://pypi.ngc.nvidia.com onnx_graphsurgeon=
 RUN pip install torch==2.3.0 torchvision==0.18.0 --index-url https://download.pytorch.org/whl/cu121
 
 # ======== Install ModelOpt Toolkit for quantization and ORT for CUDA 12 =========
-RUN pip install nvidia-modelopt[onnx]==0.15.0 --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/
+RUN pip install nvidia-modelopt[onnx]==0.27.1
 ENV LD_LIBRARY_PATH=/usr/local/lib/python3.10/dist-packages/nvidia/cudnn/lib:$LD_LIBRARY_PATH
 
 # ======== Prepare repo to convert BEVFormer model from PyTorch to ONNX ========

--- a/AV-Solutions/bevformer-int8-eq/results/deploy_trt.sh
+++ b/AV-Solutions/bevformer-int8-eq/results/deploy_trt.sh
@@ -10,8 +10,8 @@ BEVFORMER_REPO=/workspace/BEVFormer_tensorrt
 ROOT_DIR=$(pwd)
 
 MODEL_NAMES=(
-  bevformer_tiny_epoch_24_cp_op13_post_simp
-  bevformer_tiny_epoch_24_cp2_op13_post_simp
+  bevformer_tiny_epoch_24_cp_op13
+  bevformer_tiny_epoch_24_cp2_op13
 )
 
 PLUGIN_PATH="/workspace/BEVFormer_tensorrt/TensorRT/lib/libtensorrt_ops.so"
@@ -44,7 +44,8 @@ for (( i=0; i<$len; i++ )); do
     --output_path=${MODEL_DIR}/${MODEL_NAME}.quant.onnx \
     --trt_plugins=$PLUGIN_PATH \
     --op_types_to_exclude MatMul \
-    --calibration_data_path=$CALIB_PATH
+    --calibration_data_path=$CALIB_PATH \
+    --simplify
   wait
   for PRECISION in best; do
     echo "    - ${PRECISION}"

--- a/AV-Solutions/bevformer-int8-eq/results/evaluate_trt.sh
+++ b/AV-Solutions/bevformer-int8-eq/results/evaluate_trt.sh
@@ -5,8 +5,8 @@ LOGS_DIR="${MODEL_DIR}/logs_${DEVICE}_trt${TRT_VERSION}"
 BEVFORMER_REPO=/workspace/BEVFormer_tensorrt
 
 MODEL_NAMES=(
-  bevformer_tiny_epoch_24_cp_op13_post_simp
-  bevformer_tiny_epoch_24_cp2_op13_post_simp
+  bevformer_tiny_epoch_24_cp_op13
+  bevformer_tiny_epoch_24_cp2_op13
 )
 
 PLUGIN_PATH="/workspace/BEVFormer_tensorrt/TensorRT/lib/libtensorrt_ops.so"

--- a/AV-Solutions/bevformer-int8-eq/results/onnx2trt_calib_npz.py
+++ b/AV-Solutions/bevformer-int8-eq/results/onnx2trt_calib_npz.py
@@ -57,7 +57,6 @@ def parse_args():
     parser.add_argument(
         "--calibrator", type=str, default=None, help="[legacy, entropy, minmax]"
     )
-    # parser.add_argument("--plugin", default="/workspace/BEVFormer_tensorrt/TensorRT/lib/libtensorrt_ops.so")
     parser.add_argument(
         "--trt_plugins",
         type=str,

--- a/AV-Solutions/bevformer-int8-eq/tools/onnx_postprocess.py
+++ b/AV-Solutions/bevformer-int8-eq/tools/onnx_postprocess.py
@@ -21,7 +21,6 @@ from typing import Dict, List, Tuple
 import argparse
 import numpy as np
 import onnx
-from onnxsim import simplify
 import onnx_graphsurgeon as gs
 import tensorrt as trt
 
@@ -31,8 +30,7 @@ def parse_args():
         "Simplifies an ONNX model with custom TensorRT (TRT) plugins. Steps: \n"
         "  1. Automatically detect custom TRT ops in the ONNX model.\n"
         "  2. Ensure that the custom ops are supported as a TRT plugin in ONNX-Runtime (`trt.plugins` domain).\n"
-        "  3. Use ONNX-GraphSurgeon to update all tensor types and shapes in the ONNX graph.\n"
-        "  4. Apply onnxsim to simplify model with inferred shapes."
+        "  3. Use ONNX-GraphSurgeon to update all tensor types and shapes in the ONNX graph."
     )
     parser.add_argument("--onnx", type=str, required=True, help="Input ONNX model path.")
     parser.add_argument("--trt_plugins", type=str, default=None,
@@ -256,16 +254,6 @@ def main():
 
     if has_custom_op:
         print(f"Found {len(custom_ops)} custom ops: {custom_ops}")
-
-        # Simplify ONNX model with inferred shapes
-        print(f"Simplifying ONNX model with inferred shapes...")
-        model_simp, check = simplify(model)
-        if check:
-            output_path = onnx_path.replace(".onnx", "_post_simp.onnx")
-            onnx.save(model_simp, output_path)
-            print(f"Simplified model was validated and saved in {output_path}")
-        else:
-            print(f"Simplified ONNX model could not be validated.")
     else:
         print("No custom ops found!")
 

--- a/AV-Solutions/bevformer-int8-eq/tools/quantize_model.py
+++ b/AV-Solutions/bevformer-int8-eq/tools/quantize_model.py
@@ -72,6 +72,11 @@ def parse_args():
             " the original ONNX model with an appropriate suffix."
         ),
     )
+    parser.add_argument(
+        "--simplify",
+        action="store_true",
+        help="If True, the given ONNX model will be simplified before quantization is performed.",
+    )
     args = parser.parse_args()
     return args
 
@@ -93,6 +98,7 @@ def main():
         op_types_to_exclude=args.op_types_to_exclude,
         trt_plugins=args.trt_plugins,
         output_path=args.output_path,
+        simplify=args.simplify,
     )
 
 


### PR DESCRIPTION
This PR updates ModelOpt from 0.15.0 to 0.27.1:
- ONNX processing before ModelOpt quantization is no longer needed, although that script is still needed to generate the calibration data.
- Enables model simplification in ModelOpt via the `--simplify` flag.

ModelOpt v0.27.1 automatically installs `onnxruntime-gpu==1.20.2`, which also fixes an issue observed during calibration data generation with the `base` variant (https://github.com/NVIDIA/DL4AGX/issues/85#issuecomment-2803076968).