### PR TITLE
[BEVFormer] Update ModelOpt to 0.41.0, support IQ deprecation (replace 'best' with 'stronglyTyped')

### DIFF
--- a/AV-Solutions/bevformer-int8-eq/README.md
+++ b/AV-Solutions/bevformer-int8-eq/README.md
@@ -4,11 +4,10 @@ This repository contains an end-to-end example of deploying [BEVFormer](https://
 
 # Requirements
 - TensorRT 10.x
-- ONNX-Runtime 1.20.x
 - onnx-graphsurgeon
-- onnxsim
-- [ModelOpt toolkit](https://github.com/NVIDIA/TensorRT-Model-Optimizer) 0.29.0
+- [ModelOpt toolkit](https://github.com/NVIDIA/Model-Optimizer) 0.41.0
 - [BEVFormer_tensorrt](https://github.com/DerryHub/BEVFormer_tensorrt)
+- PyTorch 2.9.0
 
 ## Prepare dataset
 Follow the [Data Preparation steps](https://github.com/DerryHub/BEVFormer_tensorrt#nuscenes-and-can-bus-for-bevformer) for NuScenes and CAN bus.
@@ -17,7 +16,7 @@ Follow the [Data Preparation steps](https://github.com/DerryHub/BEVFormer_tensor
 ## Prepare docker image
 Build docker image:
 ```bash
-$ export TAG=tensorrt_bevformer:25.04
+$ export TAG=tensorrt_bevformer:26.01
 $ docker build -f docker/tensorrt.Dockerfile --no-cache --tag=$TAG .
 ```
 
@@ -86,8 +85,7 @@ $ PYTHONPATH=$(pwd) python /mnt/tools/calib_data_prep.py configs/bevformer/plugi
 $ python -m modelopt.onnx.quantization --onnx_path=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.onnx \
       --trt_plugins=$PLUGIN_PATH \
       --op_types_to_exclude MatMul \
-      --calibration_data_path=/workspace/BEVFormer_tensorrt/data/nuscenes/calib_data.npz \
-      --simplify
+      --calibration_data_path=/workspace/BEVFormer_tensorrt/data/nuscenes/calib_data.npz
 ```
 > This generates an ONNX model with suffix `.quant.onnx` with Q/DQ nodes around relevant layers.
 
@@ -98,7 +96,6 @@ $ python -m modelopt.onnx.quantization --onnx_path=/mnt/models/bevformer_tiny_ep
   This is up to the user to decide.
 - If you're running out of memory, you may need to add `CUDA_MODULE_LOADING=LAZY` to the beginning of that
   quantization command. This is only valid for CUDA 12.x. No such variable is needed with CUDA 11.8.
-- The `--simplify` flag is optional.
 - If you wish to simply check the explicitly quantized model's runtime performance, without considering its accuracy,
   you may also skip using the `--calibration_data_path` flag (and thus `Step 2` altogether).
 
@@ -107,7 +104,7 @@ $ python -m modelopt.onnx.quantization --onnx_path=/mnt/models/bevformer_tiny_ep
 $ trtexec --onnx=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.quant.onnx \
 	      --saveEngine=/mnt/models/bevformer_tiny_epoch_24_cp2_op13.quant.engine \
 	      --staticPlugins=$PLUGIN_PATH \
-	      --best
+	      --stronglyTyped
 ```
 
 **Note**: In order to deploy the quantized ONNX model in another platform or with another TensorRT version, simply
@@ -124,25 +121,25 @@ $ python tools/bevformer/evaluate_trt.py \
 ```
 
 # Results
-**System**: NVIDIA A40 GPU, TensorRT 10.9.0.34
+**System**: NVIDIA A40 GPU, TensorRT 10.14.1.48
 
 BEVFormer tiny with FP16 plugins with `nv_half2` (`bevformer_tiny_epoch_24_cp2_op13.onnx`):
 
-| Precision                                       | GPU Compute Time (median, ms) | Accuracy (NDS / mAP)   |
-|-------------------------------------------------|-------------------------------|------------------------|
-| FP32                                            | 17.82                         | NDS: 0.355, mAP: 0.252 |
-| FP16                                            | 8.91                          | NDS: 0.355, mAP: 0.252 |
-| BEST (TensorRT PTQ - Implicit Quantization)     | 6.00                          | NDS: 0.353, mAP: 0.249 |
-| QDQ_BEST (ModelOpt PTQ - Explicit Quantization) | 5.75                          | NDS: 0.352, mAP: 0.251 |
+| Precision                                               | GPU Compute Time (median, ms) | Accuracy (NDS / mAP)   |
+|---------------------------------------------------------|-------------------------------|------------------------|
+| FP32                                                    | 18.68                         | NDS: 0.355, mAP: 0.252 |
+| FP16                                                    | 9.27                          | NDS: 0.355, mAP: 0.252 |
+| IQ_BEST (TensorRT PTQ - Implicit Quantization)          | 6.16                          | NDS: 0.353, mAP: 0.249 |
+| EQ_StronglyTyped (ModelOpt PTQ - Explicit Quantization) | 5.76                          | NDS: 0.352, mAP: 0.251 |
 
 BEVFormer tiny with FP16 plugins with `nv_half` (`bevformer_tiny_epoch_24_cp_op13.onnx`):
 
-| Precision                                       | GPU Compute Time (median, ms) | Accuracy (NDS / mAP)   |
-|-------------------------------------------------|-------------------------------|------------------------|
-| FP32                                            | 17.79                         | NDS: 0.355, mAP: 0.252 |
-| FP16                                            | 9.46                          | NDS: 0.355, mAP: 0.252 |
-| BEST (TensorRT PTQ - Implicit Quantization)     | 6.30                          | NDS: 0.347, mAP: 0.248 |
-| QDQ_BEST (ModelOpt PTQ - Explicit Quantization) | 6.22                          | NDS: 0.352, mAP: 0.251 |
+| Precision                                               | GPU Compute Time (median, ms) | Accuracy (NDS / mAP)   |
+|---------------------------------------------------------|-------------------------------|------------------------|
+| FP32                                                    | 18.65                         | NDS: 0.355, mAP: 0.252 |
+| FP16                                                    | 9.72                          | NDS: 0.355, mAP: 0.252 |
+| IQ_BEST (TensorRT PTQ - Implicit Quantization)          | 6.41                          | NDS: 0.352, mAP: 0.248 |
+| EQ_StronglyTyped (ModelOpt PTQ - Explicit Quantization) | 6.22                          | NDS: 0.352, mAP: 0.251 |
 
 ## Steps to reproduce
 To reproduce the results, run:

--- a/AV-Solutions/bevformer-int8-eq/bevformer_trt10.patch
+++ b/AV-Solutions/bevformer-int8-eq/bevformer_trt10.patch
@@ -474,10 +474,10 @@ index d5808b9..e8f7030 100644
  
  #endif // TENSORRT_OPS_ROTATEKERNEL_H
 diff --git a/det2trt/convert/pytorch2onnx.py b/det2trt/convert/pytorch2onnx.py
-index 978e544..a01c8b4 100644
+index 978e544..ca15628 100644
 --- a/det2trt/convert/pytorch2onnx.py
 +++ b/det2trt/convert/pytorch2onnx.py
-@@ -62,12 +62,13 @@ def pytorch2onnx(
+@@ -62,12 +62,14 @@ def pytorch2onnx(
          input_names=input_name,
          output_names=output_name,
          export_params=True,
@@ -490,6 +490,7 @@ index 978e544..a01c8b4 100644
          dynamic_axes=dynamic_axes,
          operator_export_type=OperatorExportTypes.ONNX_FALLTHROUGH,
 +        autograd_inlining=False,
++        dynamo=False,
      )
  
      print(f"ONNX file has been saved in {output_file}")

--- a/AV-Solutions/bevformer-int8-eq/docker/tensorrt.Dockerfile
+++ b/AV-Solutions/bevformer-int8-eq/docker/tensorrt.Dockerfile
@@ -1,9 +1,9 @@
-FROM nvcr.io/nvidia/tensorrt:25.04-py3
+FROM nvcr.io/nvidia/tensorrt:26.01-py3
 
 ARG CMAKE_VERSION=3.29.3
 ARG NUM_JOBS=8
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV PROJECT_DIR=/workspace
 
 # Install package dependencies
@@ -36,9 +36,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # System locale
 # Important for UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
 
 # Install CMake
 RUN cd /tmp && \
@@ -48,19 +48,20 @@ RUN rm -rf /tmp/*
 
 RUN pip install --upgrade pip
 RUN pip install setuptools wheel
-RUN pip install cuda-python==12.6.2 \
-                numpy==1.26.3 \
-                onnx==1.17.0 \
-                onnxsim
+RUN pip install cuda-python==13.1.0
 RUN pip install --extra-index-url https://pypi.ngc.nvidia.com onnx_graphsurgeon==0.5.8
-RUN pip install torch==2.6.0 torchvision==0.21.0 --index-url https://download.pytorch.org/whl/cu126
+RUN pip install torch==2.9.0 torchvision==0.24.0 --index-url https://download.pytorch.org/whl/cu130
 
-# ======== Install ModelOpt Toolkit for quantization and ORT for CUDA 12 =========
-RUN pip install nvidia-modelopt[onnx]==0.29.0
-ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+# ======== Install ModelOpt Toolkit for quantization =========
+# Install ModelOpt
+RUN pip install nvidia-modelopt[onnx]==0.41.0
+# Install ONNX-Runtime 1.24.x for CUDA 13.x support (needed in ModelOpt quantization)
+RUN pip install --pre --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-13-nightly/pypi/simple/ onnxruntime-gpu==1.24.0.dev20260123002
+# Export library environment variables
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/cuda-13.1/targets/x86_64-linux/lib:$LD_LIBRARY_PATH
 
 # ======== Prepare repo to convert BEVFormer model from PyTorch to ONNX ========
-ARG TORCH_CUDA_ARCH_LIST="7.5;6.1;8.0;8.6"
+ARG TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6"
 ENV FORCE_CUDA="1"
 ENV TRT_LIBPATH="/usr/lib/x86_64-linux-gnu"
 
@@ -78,22 +79,22 @@ RUN head -n $(($(wc -l < ${DERRYHUB_PROJECT_DIR}/requirements.txt) - 3)) ${DERRY
 
 # Install pytorch-quantization from source (needed for PyTorch 2 support)
 # WAR for issue with package installed via "pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com pytorch-quantization"
-RUN cd ${PROJECT_DIR} && git clone https://github.com/NVIDIA/TensorRT.git -b release/10.9 && \
+RUN cd ${PROJECT_DIR} && git clone https://github.com/NVIDIA/TensorRT.git -b release/10.14 && \
     cd TensorRT/tools/pytorch-quantization && \
     MAX_JOBS=4 python setup.py install
 
 # Install MMCV. First replace c++14 by c++17 to be able to compile PyTorch 2.x then do pip install with MAX_JOBS=4 to prevent workstation from freezing.
-RUN cd ${DERRYHUB_PROJECT_DIR} && \
+RUN cd ${DERRYHUB_PROJECT_DIR}/third_party && \
     git clone https://github.com/open-mmlab/mmcv.git && \
     cd mmcv && git checkout v1.5.0 && \
     pip install -r requirements/optional.txt && \
     sed -i "s/c++14/c++17/g" setup.py && \
-    MAX_JOBS=4 MMCV_WITH_OPS=1 pip install -v -e .
+    MAX_JOBS=4 MMCV_WITH_OPS=1 pip install -v -e . --no-build-isolation
 
-RUN cd ${DERRYHUB_PROJECT_DIR} && \
+RUN cd ${DERRYHUB_PROJECT_DIR}/third_party && \
     git clone https://github.com/open-mmlab/mmdetection.git && \
     cd mmdetection && git checkout v2.25.1 && \
-    pip install -v .
+    pip install -v . --no-build-isolation
 
 RUN cd ${DERRYHUB_PROJECT_DIR}/third_party/bev_mmdet3d && \
     MAX_JOBS=4 python setup.py build develop --user

--- a/AV-Solutions/bevformer-int8-eq/results/deploy_trt.sh
+++ b/AV-Solutions/bevformer-int8-eq/results/deploy_trt.sh
@@ -1,6 +1,6 @@
 MODEL_DIR="/mnt/models"
 CALIB_PATH="/workspace/BEVFormer_tensorrt/data/nuscenes/calib_data.npz"
-TRT_VERSION="10.9.0.34"
+TRT_VERSION="10.14.1.48"
 DEVICE="A40"
 
 LOGS_DIR="${MODEL_DIR}/logs_${DEVICE}_trt${TRT_VERSION}"
@@ -44,21 +44,17 @@ for (( i=0; i<$len; i++ )); do
       --output_path=${MODEL_DIR}/${MODEL_NAME}.quant.onnx \
       --trt_plugins=$PLUGIN_PATH \
       --op_types_to_exclude MatMul \
-      --calibration_data_path=$CALIB_PATH \
-      --simplify
+      --calibration_data_path=$CALIB_PATH
   wait
-  for PRECISION in best; do
-    echo "    - ${PRECISION}"
-    trtexec --onnx=${MODEL_DIR}/${MODEL_NAME}.quant.onnx \
-            --staticPlugins=$PLUGIN_PATH \
-            --saveEngine=${LOGS_DIR}/${MODEL_NAME}_qat_${PRECISION}.engine \
-            --${PRECISION} &> ${LOGS_DIR}/${MODEL_NAME}_qat_${PRECISION}_trtexec.log
-    wait
-  done
+  trtexec --onnx=${MODEL_DIR}/${MODEL_NAME}.quant.onnx \
+          --staticPlugins=$PLUGIN_PATH \
+          --saveEngine=${LOGS_DIR}/${MODEL_NAME}_EQ_stronglyTyped.engine \
+          --stronglyTyped &> ${LOGS_DIR}/${MODEL_NAME}_EQ_stronglyTyped_trtexec.log
+  wait
 
   echo "Quantize model - TensorRT PTQ (Implicit Quantization):"
   cd $BEVFORMER_REPO
-  IQ_ENGINE_PATH=${LOGS_DIR}/${MODEL_NAME}_IQ_PTQ
+  IQ_ENGINE_PATH=${LOGS_DIR}/${MODEL_NAME}_IQ_best
   python /mnt/results/onnx2trt_calib_npz.py configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
         --onnx_path=${MODEL_DIR}/${MODEL_NAME}.onnx \
         --output=${IQ_ENGINE_PATH}.engine \

--- a/AV-Solutions/bevformer-int8-eq/results/evaluate_trt.sh
+++ b/AV-Solutions/bevformer-int8-eq/results/evaluate_trt.sh
@@ -1,5 +1,5 @@
 MODEL_DIR="/mnt/models"
-TRT_VERSION="10.9.0.34"
+TRT_VERSION="10.14.1.48"
 DEVICE="A40"
 LOGS_DIR="${MODEL_DIR}/logs_${DEVICE}_trt${TRT_VERSION}"
 BEVFORMER_REPO=/workspace/BEVFormer_tensorrt
@@ -32,18 +32,15 @@ for (( i=0; i<$len; i++ )); do
   done
 
   echo "Quantized - ModelOpt PTQ (Explicit Quantization):"
-  for PRECISION in best; do
-    echo "  - ${PRECISION}"
-    ENGINE_PATH=${LOGS_DIR}/${MODEL_NAME}_qat_${PRECISION}
-    python tools/bevformer/evaluate_trt.py \
-            configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
-            ${ENGINE_PATH}.engine \
-            --trt_plugins=$PLUGIN_PATH | tee ${ENGINE_PATH}_acc.log
-    wait
-  done
+  ENGINE_PATH=${LOGS_DIR}/${MODEL_NAME}_EQ_stronglyTyped
+  python tools/bevformer/evaluate_trt.py \
+          configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
+          ${ENGINE_PATH}.engine \
+          --trt_plugins=$PLUGIN_PATH | tee ${ENGINE_PATH}_acc.log
+  wait
 
   echo "Quantized - TensorRT PTQ (Implicit Quantization):"
-  ENGINE_PATH=${LOGS_DIR}/${MODEL_NAME}_IQ_PTQ
+  ENGINE_PATH=${LOGS_DIR}/${MODEL_NAME}_IQ_best
   python tools/bevformer/evaluate_trt.py \
           configs/bevformer/plugin/bevformer_tiny_trt_p2.py \
           ${ENGINE_PATH}.engine \

--- a/AV-Solutions/bevformer-int8-eq/tools/onnx_postprocess.py
+++ b/AV-Solutions/bevformer-int8-eq/tools/onnx_postprocess.py
@@ -243,6 +243,9 @@ def load_ort_supported_model(
             onnx.helper.make_opsetid(trt_plugin_domain, trt_plugin_version)
         )
 
+    # Avoids error: "Unsupported model IR version: 12, max supported IR version: 10"
+    onnx_model.ir_version = 10
+
     return onnx_model, has_custom_op, custom_ops
 
 


### PR DESCRIPTION
This MR replaces `--best` for `--stronglyTyped` in the TensorRT deployment stage to match TensorRT's recommendation towards explicit quantization. This is related to the deprecation of the implicit quantization workflow in TensorRT.

Other updates:
- TRT docker: 26.01
- ModelOpt: 0.41.0
- PyTorch: 0.29.0